### PR TITLE
Adding url tracking events

### DIFF
--- a/Chapters.md
+++ b/Chapters.md
@@ -11,7 +11,7 @@ author: Touko
   <li><a href="mailto:proteusleatheruki@gmail.com" data-umami-event="Email-UK-Click">Email</a></li>
   <li><a href="https://twitter.com/ProteusLthrUKI" data-umami-event="Twitter-UK-Click">Twitter</a></li>
   <li><a href="https://www.instagram.com/proteuslthruki/" data-umami-event="Instagram-UK-Click">Instagram</a></li>
-  <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSesCkE8_NNMP6MGhoWnjwWTc5gyu6pjnO0fh8csgxkwi004TA/viewform?usp=sf_link" data-umami-event="Fourm-UK-Click">Membership Form</a></li>
+  <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSesCkE8_NNMP6MGhoWnjwWTc5gyu6pjnO0fh8csgxkwi004TA/viewform?usp=sf_link" data-umami-event="Form-UK-Click">Membership Form</a></li>
   <li>Chapter Head: Mal (he/him)</li>
   <li>Sergeant-At-Arms: Touko (he/him)</li>
 </ul>

--- a/Chapters.md
+++ b/Chapters.md
@@ -7,23 +7,27 @@ author: Touko
 
 ## UK & Ireland
 
-- [Email](mailto:proteusleatheruki@gmail.com)
-- [Twitter](https://twitter.com/ProteusLthrUKI)
-- [Instagram](https://www.instagram.com/proteuslthruki/)
-- [Membership Form](https://docs.google.com/forms/d/e/1FAIpQLSesCkE8_NNMP6MGhoWnjwWTc5gyu6pjnO0fh8csgxkwi004TA/viewform?usp=sf_link)
-- Chapter Head: Mal (he/him)
-- Sergeant-At-Arms: Touko (he/him)
+<ul>
+  <li><a href="mailto:proteusleatheruki@gmail.com" data-umami-event="Email-UK-Click">Email</a></li>
+  <li><a href="https://twitter.com/ProteusLthrUKI" data-umami-event="Twitter-UK-Click">Twitter</a></li>
+  <li><a href="https://www.instagram.com/proteuslthruki/" data-umami-event="Instagram-UK-Click">Instagram</a></li>
+  <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSesCkE8_NNMP6MGhoWnjwWTc5gyu6pjnO0fh8csgxkwi004TA/viewform?usp=sf_link" data-umami-event="Fourm-UK-Click">Membership Form</a></li>
+  <li>Chapter Head: Mal (he/him)</li>
+  <li>Sergeant-At-Arms: Touko (he/him)</li>
+</ul>
 
 <img src="/assets/proteus.png" class="chapter-spacer" />
 
 ## Germany
 
-- [Email](mailto:proteusleatherclubgermany@gmail.com)
-- [Twitter](https://twitter.com/ProteusLthrGer)
-- [Instagram](https://www.instagram.com/proteuslthrger/)
-- [Membership Form](https://docs.google.com/forms/d/e/1FAIpQLSd-lwPkOiR_ycQuVOsDWIvgbwGR9QBiEKhkwAbN0CUnJSkrIg/viewform?pli=1)
-- Chapter Head: Glenn/G (he/they)
-- Sergeant-At-Arms: Byron (he/him)
+<ul>
+  <li><a href="mailto:proteusleatherclubgermany@gmail.com" data-umami-event="Email-Germany-Click">Email</a></li>
+  <li><a href="https://twitter.com/ProteusLthrGer" data-umami-event="Twitter-Germany-Click">Twitter</a></li>
+  <li><a href="https://www.instagram.com/proteuslthrger/" data-umami-event="Instagram-Germany-Click">Instagram</a></li>
+  <li><a href="https://docs.google.com/forms/d/e/1FAIpQLSd-lwPkOiR_ycQuVOsDWIvgbwGR9QBiEKhkwAbN0CUnJSkrIg/viewform?pli=1" data-umami-event="Form-Germany-Click">Membership Form</a></li>
+  <li>Chapter Head: Glenn/G (he/they)</li>
+  <li>Sergeant-At-Arms: Byron (he/him)</li>
+</ul>
 
 <img src="/assets/proteus.png" class="chapter-spacer" />
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,10 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.15.5)
+    ffi (1.15.5-x64-mingw-ucrt)
     forwardable-extended (2.6.0)
     google-protobuf (3.23.3-x64-mingw-ucrt)
+    google-protobuf (3.23.3-x86_64-linux)
     http_parser.rb (0.8.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -63,6 +65,8 @@ GEM
     safe_yaml (1.0.5)
     sass-embedded (1.63.6-x64-mingw-ucrt)
       google-protobuf (~> 3.23)
+    sass-embedded (1.63.6-x86_64-linux-gnu)
+      google-protobuf (~> 3.23)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     tzinfo (2.0.6)
@@ -75,6 +79,7 @@ GEM
 
 PLATFORMS
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   http_parser.rb (~> 0.6.0)

--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -13,4 +13,4 @@
 <meta name="msapplication-TileColor" content="#da532c">
 <meta name="msapplication-config" content="/assets/images/browserconfig.xml">
 <meta name="theme-color" content="#ffffff">
-<script defer src="https://umami.raccoon-codlet.ts.net/script.js" data-website-id="dfc48547-898f-4f0b-aa73-bc98e86a979d"></script>
+<script defer src="https://umami.raccoon-codlet.ts.net/script.js" data-website-id="dfc48547-898f-4f0b-aa73-bc98e86a979d" data-domains="proteusleather.club"></script>


### PR DESCRIPTION
All external resources linked have been added, we can now follow if people viewing our site leads them to the socials/ sign up or not 

also added a data domain to the tracker tag, so it doesn't track the site when it's not loaded from the domain IE local testing/ development.